### PR TITLE
<fix>[back] fix storing trace id logic

### DIFF
--- a/back/main_sever/src/_common/exception/common/base.exception.ts
+++ b/back/main_sever/src/_common/exception/common/base.exception.ts
@@ -14,6 +14,7 @@ interface IBaseException {
 export type HttpStatusType = keyof typeof HttpStatus;
 
 export class BaseException extends HttpException implements IBaseException {
+    traceId: string;
     constructor(
         errorCode: number,
         status: number,

--- a/back/main_sever/src/_common/filter/auth-exception.filter.ts
+++ b/back/main_sever/src/_common/filter/auth-exception.filter.ts
@@ -10,7 +10,6 @@ import { AuthExceptionEnum } from '../exception/common/enum/auth-exception-code.
 export class AuthExceptionFilter extends CustomExceptionFilter {
     constructor(private readonly loggerUsecase: LoggerUsecase) {
         super(loggerUsecase, 'AuthExceptionFilter');
-        this.loggerUsecase.log(`successfully mounted`, this.className);
     }
 
     catch(exception: AuthException, host: ArgumentsHost): void {
@@ -19,7 +18,10 @@ export class AuthExceptionFilter extends CustomExceptionFilter {
         super.catch(exception, host);
 
         if (code >= AuthExceptionEnum.CREDENTIALS_REVOKED) {
-            this.loggerUsecase.error('Serious Excpetion', exception.stack, this.className);
+            this.loggerUsecase.error('Serious Excpetion', exception.stack, {
+                className: this.className,
+                traceId: exception.traceId,
+            });
         }
     }
 }

--- a/back/main_sever/src/_common/filter/common/custom-base-exception.filter.ts
+++ b/back/main_sever/src/_common/filter/common/custom-base-exception.filter.ts
@@ -52,15 +52,13 @@ export class CustomExceptionFilter implements ExceptionFilter {
                 });
             }
         } else {
-            this.logger.error(
-                `unsupport host type[${host.getType()} access`,
-                exception.stack,
-                this.className,
-            );
+            this.logger.error(`unsupport host type[${host.getType()} access`, exception.stack, {
+                className: this.className,
+                traceId: exception.traceId,
+            });
         }
     }
 
-    // 부모 클래스 타입으로 자식 클래스 타입을 판별할 수 있는가?
     private logBaseException(exception: BaseException) {
         const info: IExceptionInfo = {
             timestamp: exception.timestamp,
@@ -70,9 +68,15 @@ export class CustomExceptionFilter implements ExceptionFilter {
         };
 
         if (exception.getStatus() >= HttpStatus.INTERNAL_SERVER_ERROR) {
-            this.logger.error(JSON.stringify(info, null, 2), exception.stack, this.className);
+            this.logger.error(JSON.stringify(info, null, 2), exception.stack, {
+                className: this.className,
+                traceId: exception.traceId,
+            });
         } else {
-            this.logger.warn(JSON.stringify(info, null, 2), this.className);
+            this.logger.warn(JSON.stringify(info, null, 2), {
+                className: this.className,
+                traceId: exception.traceId,
+            });
         }
     }
 
@@ -87,7 +91,10 @@ export class CustomExceptionFilter implements ExceptionFilter {
         this.logger.error(
             `Unknown Exception ${e.name} occurs ` + `${JSON.stringify(info, null, 2)}`,
             e.stack,
-            this.className,
+            {
+                className: this.className,
+                traceId: e.traceId,
+            },
         );
     }
 

--- a/back/main_sever/src/_common/filter/service-exception.filter.ts
+++ b/back/main_sever/src/_common/filter/service-exception.filter.ts
@@ -16,7 +16,6 @@ interface IExceptionInfo extends Pick<BaseException, 'timestamp' | 'path'> {
 export class ServiceExceptionFilter extends CustomExceptionFilter {
     constructor(private readonly loggerUsecase: LoggerUsecase) {
         super(loggerUsecase, 'ServiceExceptionFilter');
-        this.loggerUsecase.log(`successfully mounted`, this.className);
     }
 
     catch(exception: ServiceException, host: ArgumentsHost): void {
@@ -26,7 +25,10 @@ export class ServiceExceptionFilter extends CustomExceptionFilter {
 
         if (code == ServiceExceptionEnum.DB_INCONSISTENCY) {
             // notfiy to Developer.
-            this.loggerUsecase.error('DB has inconsistency', exception.stack, this.className);
+            this.loggerUsecase.error('DB has inconsistency', exception.stack, {
+                className: this.className,
+                traceId: exception.traceId,
+            });
         }
     }
 }

--- a/back/main_sever/src/_common/interceptor/logging.interceptor.ts
+++ b/back/main_sever/src/_common/interceptor/logging.interceptor.ts
@@ -66,7 +66,9 @@ export class HttpLoggingInterceptor implements NestInterceptor {
                 `header : ${JSON.stringify(headers, null, 2)}` +
                 `Params: ${JSON.stringify(params)}` +
                 `Query: ${JSON.stringify(query)}`,
-            this.className,
+            {
+                className: this.className,
+            },
         );
 
         return { request, response, body: val } as HttpInfo;
@@ -83,7 +85,9 @@ export class HttpLoggingInterceptor implements NestInterceptor {
                 `Body: ${JSON.stringify(body, null, 2)}\n` +
                 `[RESPONSE]\n` +
                 `body :${JSON.stringify(v.body, null, 2)}`,
-            this.className,
+            {
+                className: this.className,
+            },
         );
     }
 
@@ -108,9 +112,13 @@ export class HttpLoggingInterceptor implements NestInterceptor {
             `Headers: ${JSON.stringify(headers, null, 2)}\n`;
 
         if (httpStatus < 500) {
-            this.loggerUsecase.warn(format, this.className);
+            this.loggerUsecase.warn(format, {
+                className: this.className,
+            });
         } else {
-            this.loggerUsecase.error(format, error.stack, this.className);
+            this.loggerUsecase.error(format, error.stack, {
+                className: this.className,
+            });
         }
     }
 

--- a/back/main_sever/src/_common/provider/LoggerUsecase.ts
+++ b/back/main_sever/src/_common/provider/LoggerUsecase.ts
@@ -1,6 +1,11 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ClsService } from 'nestjs-cls';
 
+export interface ILogContext {
+    className: string;
+    traceId?: string;
+}
+
 @Injectable()
 export class LoggerUsecase {
     static KEY = {
@@ -13,36 +18,28 @@ export class LoggerUsecase {
         private readonly clsService: ClsService,
     ) {}
 
-    debug(message: any, context: string) {
+    debug(message: any, context: ILogContext) {
         return this.logger.debug(message, this.getFullContext(context));
     }
-    log(message: any, context: string) {
+    log(message: any, context: ILogContext) {
         return this.logger.log(message, this.getFullContext(context));
     }
-    error(message: any, stack: string, context: string) {
+    error(message: any, stack: string, context: ILogContext) {
         return this.logger.error(message, stack, this.getFullContext(context));
     }
 
-    fatal(message: any, stack: string, context: string) {
+    fatal(message: any, stack: string, context: ILogContext) {
         return this.logger.fatal(message, stack, this.getFullContext(context));
     }
-    verbose(message: any, context: string) {
+    verbose(message: any, context: ILogContext) {
         return this.logger.verbose(message, this.getFullContext(context));
     }
-    warn(message: any, context: string) {
+    warn(message: any, context: ILogContext) {
         return this.logger.warn(message, this.getFullContext(context));
     }
 
-    private getFullContext(ctx: string) {
-        const reqInfo = this.clsService.get(LoggerUsecase.KEY.traceReq) || this.traceId;
-        return `${ctx} , req{${reqInfo}}`;
-    }
-
-    set traceId(value: string) {
-        this._traceId = value;
-    }
-
-    get traceId() {
-        return this._traceId;
+    private getFullContext(ctx: ILogContext) {
+        const reqInfo = this.clsService.get(LoggerUsecase.KEY.traceReq) || ctx.traceId;
+        return `${ctx.className} , req{${reqInfo}}`;
     }
 }


### PR DESCRIPTION
- fix logging wrong request id because stored trace id of LoggerUsecase is not initialized after exception filter execution
- ASIS
 - store trace id of request to LoggerUsecase when error occur
- TOBE
 - store trace id of request to error instance which caues error when error occur
 - Exception filter needs to delivery trace id of error as parameter when calls log method of LoggerUsecase

#### 관련 이슈 <!--  Notion Link-->

#### 변경 사항 및 이유 <!-- 변경한 내용과 그 이유를 적어주세요. --> 
- fix logging wrong request id 

#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 --> 

#### 참고 사항 <!-- 참고할 사항이 있다면 적어주세요. -->
